### PR TITLE
Main: рефактор по-братски

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,63 +1,84 @@
-import numpy as np
-from pandas import read_csv, DataFrame, Series
-import matplotlib.pyplot as plt
-import pymongo
+from pandas import read_csv
 from pymongo import MongoClient
+from scipy.stats import shapiro
 from sklearn import cross_validation
 from sklearn.preprocessing import LabelEncoder
-from scipy.stats import shapiro
-import json
+
+PASSENGER_DATA_LOCATION = "train.csv"
 
 
-def write_in_db(json_data):
-    client = MongoClient()
-    connection = MongoClient()
-    db = connection.mach_learn
-    collection = db.collect
-    collection.insert(json_data)
-    connection.close()
+def write_in_db(data: dict):
+    collection = mach_learn_table.collect
+    collection.insert(data)
 
 
-def fill_data(data):
-    data.Age[data.Age.isnull()] = data.Age.mean()
-    data.Fare[data.Fare.isnull()] = data.Fare.median()  # заполняем пустые значения средней ценой билета
-    MaxPassEmbarked = data.groupby('Embarked').count()['PassengerId']
-    label.fit(data['Sex'])
-    data.Embarked[data.Embarked.isnull()] = MaxPassEmbarked[MaxPassEmbarked == MaxPassEmbarked.max()].index[0]
-    data.Sex = label.transform(data.Sex)
-    label.fit(data['Embarked'])
-    data.Embarked = label.transform(data.Embarked)
-    return data
+def fill_passengers(passengers):
+    label_encoder = LabelEncoder()
+    passengers.Age[passengers.Age.isnull()] = passengers.Age.mean()
+    # заполняем пустые значения средней ценой билета
+    passengers.Fare[passengers.Fare.isnull()] = passengers.Fare.median()
+    max_pass_embarked = passengers.groupby('Embarked').count()['PassengerId']
+    label_encoder.fit(passengers['Sex'])
+    passengers.Embarked[passengers.Embarked.isnull()] = \
+        max_pass_embarked[max_pass_embarked == max_pass_embarked.max()].index[0]
+    passengers.Sex = label_encoder.transform(passengers.Sex)
+    label_encoder.fit(passengers['Embarked'])
+    passengers.Embarked = label_encoder.transform(passengers.Embarked)
+
+    return passengers
 
 
-def information_about_data(input):
+def evaluate_meta_information(passengers) -> dict:
+    default_passengers = {key: int(value.isnull().sum()) for key, value in
+                          passengers.items()}
+
+    dropped_fields = ['PassengerId', 'Name', 'Ticket', 'Cabin']
+    full_passenger = fill_passengers(passengers).drop(dropped_fields, axis=1)
+
     type_of_column = {}
-    max = {}  # max of column
-    min = {}  # min of column
-    dis = {}  # distribution of column
-    for x in input:
-        type_of_column[x] = str(input[x].dtype)
-        max[x] = int(input[x].max())
-        min[x] = int(input[x].min())
-        dis[x] = shapiro(input[x])
-    return json.dumps({'type_of_column': type_of_column, 'max': max, 'min': min, 'dis': dis})
+    max_column = {}  # max of column
+    min_column = {}  # min of column
+    distribution = {}  # distribution of column
+
+    for key, value in full_passenger.items():
+        type_of_column[key] = str(value.dtype)
+        max_column[key] = int(value.max())
+        min_column[key] = int(value.min())
+        distribution[key] = shapiro(value)
+
+    return {
+        'type_of_column': type_of_column,
+        'max': max_column,
+        'min': min_column,
+        'dis': distribution,
+        'empty': default_passengers
+    }
+
+
+def main():
+    passengers = read_csv(PASSENGER_DATA_LOCATION, delimiter=",")
+    write_in_db(evaluate_meta_information(passengers))
+
+    target = passengers.Survived  # указываем показатель для исследования
+    train = passengers.drop(['Survived'], axis=1)
+    x_train, x_test, y_train, y_test = cross_validation.train_test_split(
+        train,
+        target,
+        test_size=0.25
+    )
+
+    write_in_db({
+        'X_train': x_train.to_json(),
+        'X_test': x_test.to_json(),
+        'Y_train': y_train.to_json(),
+        'Y_test': y_test.to_json()
+    })
 
 
 if __name__ == "__main__":
-    empty = {}
-    label = LabelEncoder()
-    path = "train.csv"
-    data = read_csv(path, delimiter=",")
+    db_connection = MongoClient()
+    mach_learn_table = db_connection.mach_learn
 
-    for x in data:
-        empty[x] = int(data[x].isnull().sum())
-    data = fill_data(data)
-    data = data.drop(['PassengerId', 'Name', 'Ticket', 'Cabin'], axis=1)
-    json_data = json.loads(information_about_data(data))
-    json_data['empty'] = empty
-    write_in_db(json_data)
-    target =  data.Survived     #указываем показатель для исследования
-    train = data.drop(['Survived'], axis=1)
-    X_train, X_test, Y_train, Y_test = cross_validation.train_test_split(train, target, test_size=0.25)
-    print(Y_train.to_json())
-    write_in_db({'X_train': X_train.to_json(), 'X_test': X_test.to_json(),'Y_train': Y_train.to_json(), 'Y_test': Y_test.to_json() })
+    main()
+
+    db_connection.close()


### PR DESCRIPTION
## Описание 
- Убрал неиспользуемые импорты 
- Оптимизировал `write_to_db()` - клиент больше не инициализируется каждый раз при записи 
- Same goes для `LabelEncoder` 
- Где можно заменил циклы на list/dict comprehension
- Пофиксил скоуп в `if __name__ == "__main__"`
- Убрал ненужное преобразование dict -> Json -> dict 
- Попдправил код под PEP8
- Naming 
- Добавил шальной type hint для функции `evaluate_meta_information()` (может не работать под python ниже 3.5) 